### PR TITLE
Fix icon path issues on Mac

### DIFF
--- a/InitGui.py
+++ b/InitGui.py
@@ -26,7 +26,7 @@ class UselessWorkbench(FreeCADGui.Workbench):
         self.__class__.MenuText = "FreeCAD Beginner Assistant"
         self.__class__.ToolTip = "A description of the FreeCAD Beginner Assistant"
         from config import path_to_mod
-        self.__class__.Icon = os.path.join(path_to_mod, 'FreeCAD-Beginner-Assistant', 'icons', 'owl-2.png')
+        self.__class__.Icon = os.path.join(path_to_mod, 'icons', 'owl-2.png')
 
     def Initialize(self):
         """This function is executed when the workbench is first activated.

--- a/InitGui.py
+++ b/InitGui.py
@@ -19,15 +19,13 @@ import os
 import FreeCAD # noqa
 import FreeCADGui # noqa
 
-from config import path_to_mod
-
-
 class UselessWorkbench(FreeCADGui.Workbench):
     """Purpose and functionality of the UselessWorkbench."""
 
     def __init__(self):
         self.__class__.MenuText = "FreeCAD Beginner Assistant"
         self.__class__.ToolTip = "A description of the FreeCAD Beginner Assistant"
+        from config import path_to_mod
         self.__class__.Icon = os.path.join(path_to_mod, 'FreeCAD-Beginner-Assistant', 'icons', 'owl-2.png')
 
     def Initialize(self):

--- a/InitGui.py
+++ b/InitGui.py
@@ -25,8 +25,8 @@ class UselessWorkbench(FreeCADGui.Workbench):
     def __init__(self):
         self.__class__.MenuText = "FreeCAD Beginner Assistant"
         self.__class__.ToolTip = "A description of the FreeCAD Beginner Assistant"
-        from config import path_to_mod
-        self.__class__.Icon = os.path.join(path_to_mod, 'icons', 'owl-2.png')
+        from config import addon_work_dir
+        self.__class__.Icon = os.path.join(addon_work_dir, 'icons', 'owl-2.png')
 
     def Initialize(self):
         """This function is executed when the workbench is first activated.

--- a/commands.py
+++ b/commands.py
@@ -5,7 +5,7 @@ import FreeCAD # noqa
 import FreeCADGui # noqa
 
 from assistant import get_under_constrained_sketches, get_over_constrained_sketches
-from config import path_to_mod
+from config import addon_work_dir
 
 
 class AnalyseDocumentCommand:
@@ -17,7 +17,7 @@ class AnalyseDocumentCommand:
 
     def GetResources(self):
         """Return a dictionary with data that will be used by the button or menu item."""
-        return {'Pixmap': os.path.join(path_to_mod, 'icons', 'business.png'),
+        return {'Pixmap': os.path.join(addon_work_dir, 'icons', 'business.png'),
                 'Accel': "Ctrl+A",
                 'MenuText': "AnalyseDocumentCommand",
                 'ToolTip': "AnalyseDocumentCommand ToolTip"}
@@ -57,7 +57,7 @@ class OverConstrainedSketchCommand:
 
     def GetResources(self):
         """Return a dictionary with data that will be used by the button or menu item."""
-        return {'Pixmap': os.path.join(path_to_mod, 'icons', 'circle-blue.svg'),
+        return {'Pixmap': os.path.join(addon_work_dir, 'icons', 'circle-blue.svg'),
                 'Accel': "Ctrl+S",
                 'MenuText': "OverConstrainedSketchCommand",
                 'ToolTip': "OverConstrainedSketchCommand ToolTip"}

--- a/commands.py
+++ b/commands.py
@@ -17,7 +17,7 @@ class AnalyseDocumentCommand:
 
     def GetResources(self):
         """Return a dictionary with data that will be used by the button or menu item."""
-        return {'Pixmap': os.path.join(path_to_mod, 'FreeCAD-Beginner-Assistant', 'icons', 'business.png'),
+        return {'Pixmap': os.path.join(path_to_mod, 'icons', 'business.png'),
                 'Accel': "Ctrl+A",
                 'MenuText': "AnalyseDocumentCommand",
                 'ToolTip': "AnalyseDocumentCommand ToolTip"}
@@ -57,7 +57,7 @@ class OverConstrainedSketchCommand:
 
     def GetResources(self):
         """Return a dictionary with data that will be used by the button or menu item."""
-        return {'Pixmap': os.path.join(path_to_mod, 'FreeCAD-Beginner-Assistant', 'icons', 'circle-blue.svg'),
+        return {'Pixmap': os.path.join(path_to_mod, 'icons', 'circle-blue.svg'),
                 'Accel': "Ctrl+S",
                 'MenuText': "OverConstrainedSketchCommand",
                 'ToolTip': "OverConstrainedSketchCommand ToolTip"}

--- a/config.py
+++ b/config.py
@@ -3,4 +3,4 @@ import os
 import FreeCAD
 
 
-path_to_mod = os.path.dirname(os.path.abspath(__file__))
+addon_work_dir = os.path.dirname(os.path.abspath(__file__))

--- a/config.py
+++ b/config.py
@@ -3,4 +3,4 @@ import os
 import FreeCAD
 
 
-path_to_mod = os.path.join(FreeCAD.getHomePath(), 'Mod')
+path_to_mod = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
- Move path_to_mod import into Workbench init function
- Base the file path of the directory path of the current Python script file
- Rename path_to_mod var to addon_work_dir