### PR TITLE
Update icon reference in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,7 +10,7 @@
   <license file="LICENSE">LGPL-2.1-or-later</license>
   <url type="repository" branch="main">https://github.com/alekssadowski95/FreeCAD-Beginner-Assistant</url>
   <url type="bugtracker">https://github.com/alekssadowski95/FreeCAD-Beginner-Assistant/issues</url>
-  <icon>Icons/FreeCAD-Beginner-Assistant.svg</icon>
+  <icon>icons/freecad-beginner-assistant-workbench.svg</icon>
 
   <content>
     <workbench>


### PR DESCRIPTION
It looks from the repo that the actual path to the repo is `icons/reecad-beginner-assistant-workbench.svg` (lowercase `i` in `icons` and the filename was slightly different).